### PR TITLE
use grf forest pointer for predictions

### DIFF
--- a/skgrf/ensemble/instrumental_regressor.py
+++ b/skgrf/ensemble/instrumental_regressor.py
@@ -6,13 +6,13 @@ from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf.ensemble import grf
-from skgrf.ensemble.base import GRFValidationMixin
+from skgrf.ensemble.base import GRFMixin
 from skgrf.utils.validation import check_sample_weight
 
 logger = logging.getLogger(__name__)
 
 
-class GRFInstrumentalRegressor(GRFValidationMixin, RegressorMixin, BaseEstimator):
+class GRFInstrumentalRegressor(GRFMixin, RegressorMixin, BaseEstimator):
     r"""GRF Instrumental regression implementation for sci-kit learn.
 
     Provides a sklearn instrumental regression to the GRF C++ library using Cython.
@@ -188,6 +188,7 @@ class GRFInstrumentalRegressor(GRFValidationMixin, RegressorMixin, BaseEstimator
             self._get_num_threads(),  # num_threads,
             self.seed,
         )
+        self._ensure_ptr()
         return self
 
     def predict(self, X):
@@ -201,9 +202,10 @@ class GRFInstrumentalRegressor(GRFValidationMixin, RegressorMixin, BaseEstimator
         check_is_fitted(self)
         X = check_array(X)
         self._check_n_features(X, reset=False)
+        self._ensure_ptr()
 
         result = grf.instrumental_predict(
-            self.grf_forest_,
+            self.grf_forest_cpp_,
             np.asfortranarray([[]]),  # train_matrix
             np.asfortranarray([[]]),  # sparse_train_matrix
             self.outcome_index_,

--- a/skgrf/ensemble/local_linear_regressor.py
+++ b/skgrf/ensemble/local_linear_regressor.py
@@ -5,11 +5,11 @@ from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf.ensemble import grf
-from skgrf.ensemble.base import GRFValidationMixin
+from skgrf.ensemble.base import GRFMixin
 from skgrf.utils.validation import check_sample_weight
 
 
-class GRFLocalLinearRegressor(GRFValidationMixin, RegressorMixin, BaseEstimator):
+class GRFLocalLinearRegressor(GRFMixin, RegressorMixin, BaseEstimator):
     r"""GRF Local Linear Regression implementation for sci-kit learn.
 
     Provides a sklearn regressor interface to the GRF C++ library using Cython.
@@ -174,6 +174,7 @@ class GRFLocalLinearRegressor(GRFValidationMixin, RegressorMixin, BaseEstimator)
             self._get_num_threads(),  # num_threads,
             self.seed,
         )
+        self._ensure_ptr()
         return self
 
     def predict(self, X):
@@ -187,9 +188,10 @@ class GRFLocalLinearRegressor(GRFValidationMixin, RegressorMixin, BaseEstimator)
         check_is_fitted(self)
         X = check_array(X)
         self._check_n_features(X, reset=False)
+        self._ensure_ptr()
 
         result = grf.ll_regression_predict(
-            self.grf_forest_,
+            self.grf_forest_cpp_,
             np.asfortranarray(self.train_.astype("float64")),  # test_matrix
             np.asfortranarray([[]]),  # sparse_train_matrix
             self.outcome_index_,

--- a/skgrf/ensemble/quantile_regressor.py
+++ b/skgrf/ensemble/quantile_regressor.py
@@ -5,10 +5,10 @@ from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf.ensemble import grf
-from skgrf.ensemble.base import GRFValidationMixin
+from skgrf.ensemble.base import GRFMixin
 
 
-class GRFQuantileRegressor(GRFValidationMixin, RegressorMixin, BaseEstimator):
+class GRFQuantileRegressor(GRFMixin, RegressorMixin, BaseEstimator):
     r"""GRF Quantile Regression implementation for sci-kit learn.
 
     Provides a sklearn quantile regressor interface to the GRF C++ library using Cython.
@@ -134,6 +134,7 @@ class GRFQuantileRegressor(GRFValidationMixin, RegressorMixin, BaseEstimator):
             self._get_num_threads(),  # num_threads
             self.seed,
         )
+        self._ensure_ptr()
         return self
 
     def predict(self, X):
@@ -147,9 +148,10 @@ class GRFQuantileRegressor(GRFValidationMixin, RegressorMixin, BaseEstimator):
         check_is_fitted(self)
         X = check_array(X)
         self._check_n_features(X, reset=False)
+        self._ensure_ptr()
 
         result = grf.quantile_predict(
-            self.grf_forest_,
+            self.grf_forest_cpp_,
             self.quantiles,
             np.asfortranarray(self.train_.astype("float64")),
             np.asfortranarray([[]]),  # sparse_train_matrix

--- a/skgrf/ensemble/regressor.py
+++ b/skgrf/ensemble/regressor.py
@@ -5,11 +5,11 @@ from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf.ensemble import grf
-from skgrf.ensemble.base import GRFValidationMixin
+from skgrf.ensemble.base import GRFMixin
 from skgrf.utils.validation import check_sample_weight
 
 
-class GRFRegressor(GRFValidationMixin, RegressorMixin, BaseEstimator):
+class GRFRegressor(GRFMixin, RegressorMixin, BaseEstimator):
     r"""GRF Regression implementation for sci-kit learn.
 
     Provides a sklearn regressor interface to the GRF C++ library using Cython.
@@ -128,6 +128,7 @@ class GRFRegressor(GRFValidationMixin, RegressorMixin, BaseEstimator):
             self._get_num_threads(),  # num_threads,
             self.seed,
         )
+        self._ensure_ptr()
         return self
 
     def predict(self, X):
@@ -141,9 +142,10 @@ class GRFRegressor(GRFValidationMixin, RegressorMixin, BaseEstimator):
         check_is_fitted(self)
         X = check_array(X)
         self._check_n_features(X, reset=False)
+        self._ensure_ptr()
 
         result = grf.regression_predict(
-            self.grf_forest_,
+            self.grf_forest_cpp_,
             np.asfortranarray([[]]),  # train_matrix
             np.asfortranarray([[]]),  # sparse_train_matrix
             self.outcome_index_,

--- a/skgrf/ensemble/survival.py
+++ b/skgrf/ensemble/survival.py
@@ -4,11 +4,11 @@ from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf.ensemble import grf
-from skgrf.ensemble.base import GRFValidationMixin
+from skgrf.ensemble.base import GRFMixin
 from skgrf.utils.validation import check_sample_weight
 
 
-class GRFSurvival(GRFValidationMixin, BaseEstimator):
+class GRFSurvival(GRFMixin, BaseEstimator):
     r"""GRF Survival implementation for sci-kit learn.
 
     Provides a sklearn survival interface to the GRF C++ library using Cython.
@@ -136,6 +136,7 @@ class GRFSurvival(GRFValidationMixin, BaseEstimator):
             self._get_num_threads(),  # num_threads,
             self.seed,
         )
+        self._ensure_ptr()
         return self
 
     def predict_cumulative_hazard_function(self, X):
@@ -165,9 +166,10 @@ class GRFSurvival(GRFValidationMixin, BaseEstimator):
         check_is_fitted(self)
         X = check_array(X)
         self._check_n_features(X, reset=False)
+        self._ensure_ptr()
 
         result = grf.survival_predict(
-            self.grf_forest_,
+            self.grf_forest_cpp_,
             np.asfortranarray(self.train_.astype("float64")),  # test_matrix
             np.asfortranarray([[]]),  # sparse_train_matrix
             self.outcome_index_,

--- a/tests/ensemble/test_boosted_regressor.py
+++ b/tests/ensemble/test_boosted_regressor.py
@@ -29,9 +29,15 @@ class TestGRFBoostedRegressor:
         assert len(pred) == boston_X.shape[0]
 
     def test_serialize(self, boston_X, boston_y):
-        tf = tempfile.TemporaryFile()
         gbr = GRFBoostedRegressor()
+        # not fitted
+        tf = tempfile.TemporaryFile()
+        pickle.dump(gbr, tf)
+        tf.seek(0)
+        gbr = pickle.load(tf)
         gbr.fit(boston_X, boston_y)
+        # fitted
+        tf = tempfile.TemporaryFile()
         pickle.dump(gbr, tf)
         tf.seek(0)
         new_gbr = pickle.load(tf)

--- a/tests/ensemble/test_causal_regressor.py
+++ b/tests/ensemble/test_causal_regressor.py
@@ -28,9 +28,15 @@ class TestGRFCausalRegressor:
         assert len(pred) == causal_X.shape[0]
 
     def test_serialize(self, causal_X, causal_y, causal_w):
-        tf = tempfile.TemporaryFile()
         gfc = GRFCausalRegressor(n_estimators=100)
+        # not fitted
+        tf = tempfile.TemporaryFile()
+        pickle.dump(gfc, tf)
+        tf.seek(0)
+        gfc = pickle.load(tf)
         gfc.fit(causal_X, causal_y, causal_w)
+        # fitted
+        tf = tempfile.TemporaryFile()
         pickle.dump(gfc, tf)
         tf.seek(0)
         new_gfc = pickle.load(tf)

--- a/tests/ensemble/test_instrumental_regressor.py
+++ b/tests/ensemble/test_instrumental_regressor.py
@@ -28,9 +28,15 @@ class TestGRFInstrumentalRegressor:
         assert len(pred) == causal_X.shape[0]
 
     def test_serialize(self, causal_X, causal_y, causal_w):
-        tf = tempfile.TemporaryFile()
         gfi = GRFInstrumentalRegressor()
+        # not fitted
+        tf = tempfile.TemporaryFile()
+        pickle.dump(gfi, tf)
+        tf.seek(0)
+        gfi = pickle.load(tf)
         gfi.fit(causal_X, causal_y, causal_w, causal_w)
+        # fitted
+        tf = tempfile.TemporaryFile()
         pickle.dump(gfi, tf)
         tf.seek(0)
         new_gfi = pickle.load(tf)

--- a/tests/ensemble/test_local_linear_regressor.py
+++ b/tests/ensemble/test_local_linear_regressor.py
@@ -29,9 +29,15 @@ class TestGRFLocalLinearRegressor:
         assert len(pred) == boston_X.shape[0]
 
     def test_serialize(self, boston_X, boston_y):
-        tf = tempfile.TemporaryFile()
         glr = GRFLocalLinearRegressor(ll_split_cutoff=0)
+        # not fitted
+        tf = tempfile.TemporaryFile()
+        pickle.dump(glr, tf)
+        tf.seek(0)
+        glr = pickle.load(tf)
         glr.fit(boston_X, boston_y)
+        # fitted
+        tf = tempfile.TemporaryFile()
         pickle.dump(glr, tf)
         tf.seek(0)
         new_glr = pickle.load(tf)

--- a/tests/ensemble/test_quantile_regressor.py
+++ b/tests/ensemble/test_quantile_regressor.py
@@ -33,10 +33,16 @@ class TestGRFQuantileRegressor:
         assert len(pred) == boston_X.shape[0]
 
     def test_serialize(self, boston_X, boston_y):
-        tf = tempfile.TemporaryFile()
         gqr = GRFQuantileRegressor()
         gqr.quantiles = [0.2, 0.5, 0.8]
+        # not fitted
+        tf = tempfile.TemporaryFile()
+        pickle.dump(gqr, tf)
+        tf.seek(0)
+        gqr = pickle.load(tf)
         gqr.fit(boston_X, boston_y)
+        # fitted
+        tf = tempfile.TemporaryFile()
         pickle.dump(gqr, tf)
         tf.seek(0)
         new_gqr = pickle.load(tf)

--- a/tests/ensemble/test_regressor.py
+++ b/tests/ensemble/test_regressor.py
@@ -36,9 +36,15 @@ class TestGRFRegressor:
         assert len(pred) == boston_X.shape[0]
 
     def test_serialize(self, boston_X, boston_y):
-        tf = tempfile.TemporaryFile()
         gfr = GRFRegressor()
+        # not fitted
+        tf = tempfile.TemporaryFile()
+        pickle.dump(gfr, tf)
+        tf.seek(0)
+        gfr = pickle.load(tf)
         gfr.fit(boston_X, boston_y)
+        # fitted
+        tf = tempfile.TemporaryFile()
         pickle.dump(gfr, tf)
         tf.seek(0)
         new_gfr = pickle.load(tf)

--- a/tests/ensemble/test_survival.py
+++ b/tests/ensemble/test_survival.py
@@ -29,9 +29,15 @@ class TestGRFSurvival:
         assert len(pred) == lung_X.shape[0]
 
     def test_serialize(self, lung_X, lung_y):
-        tf = tempfile.TemporaryFile()
         gfs = GRFSurvival()
+        # not fitted
+        tf = tempfile.TemporaryFile()
+        pickle.dump(gfs, tf)
+        tf.seek(0)
+        gfs = pickle.load(tf)
         gfs.fit(lung_X, lung_y)
+        # fitted
+        tf = tempfile.TemporaryFile()
         pickle.dump(gfs, tf)
         tf.seek(0)
         new_gfs = pickle.load(tf)


### PR DESCRIPTION
Currently skgrf executes predictions by passing the serialized forest dict. The prediction functions deserialize the forest on every prediction, which is expensive. This PR modifies the prediction functions so that they accept pointers to already deserialized forest objects.

In order to do this, we create a Cython `GRFForest` class which serves as a container for the forest pointer. We also add an `_ensure_ptr` method, which creates this forest wrapper for a trained estimator if it does not already exist.

Since this wrapped pointer cannot be serialized, we also override the `__getstate__` and `__setstate__` methods to ensure we can pickle and unpickle each class. On unpickling, we also call `_ensure_ptr` so that the first call to predict after unpickling is not cold-started.

The result of this is that predict calls are faster. Here is a simple comparison with sample data from my experimenting with this:

```python
import timeit
from skgrf.ensemble import GRFRegressor
from sklearn.datasets import load_boston

boston_X, boston_y = load_boston(return_X_y=True)

gfr = GRFRegressor()
gfr.fit(boston_X, boston_y)

ptr = timeit.timeit(lambda : gfr.predict_ptr(boston_X), number=100)
ser = timeit.timeit(lambda : gfr.predict(boston_X), number=100)

print(ptr)
0.252420819000001
print(ser)
1.2568888119999997
```

Changes
* Add a `GRFForest` wrapper around a forest pointer in Cython, also modify all Cython predict functions to accept this object in lieu of the serialized forest dict.
* Add `_ensure_ptr()` method which creates `GRFForest` objects on trained estimators if not already existing
* Override pickle serde methods to ensure we can serde each class, because `GRFForest` objects are not serializable
* Fix the instance variable of the `GRFBoostedRegressor` from `grf_forest_` to `boosted_forests_` in docs
* Rename `GRFValidationMixin` to `GRFMixin` (it's not just validation now)