### PR TITLE
add feature importances

### DIFF
--- a/skgrf/ensemble/base.py
+++ b/skgrf/ensemble/base.py
@@ -1,0 +1,29 @@
+import numpy as np
+from sklearn.base import BaseEstimator
+from sklearn.utils.validation import check_is_fitted
+
+from skgrf import grf
+from skgrf.base import GRFMixin
+
+
+class BaseGRFForest(GRFMixin, BaseEstimator):
+    def get_split_frequencies(self, max_depth=4):
+        """Get the split frequencies of feature indexes at various depths.
+
+        :param int max_depth: The maximum depth of splits to consider
+        """
+        check_is_fitted(self)
+        return np.array(
+            grf.compute_split_frequencies(self.grf_forest_cpp_, max_depth=max_depth)
+        )
+
+    def get_feature_importances(self, decay_exponent=2, max_depth=4):
+        """Get the feature importances.
+
+        :param int decay_exponent: Exponential decay of importance by split depth
+        :param int max_depth: The maximum depth of splits to consider
+        """
+        sf = self.get_split_frequencies(max_depth=max_depth)
+        sf = sf / np.maximum(1, np.sum(sf, axis=0))
+        weight = np.arange(1.0, sf.shape[0] + 1) ** -decay_exponent
+        return np.matmul(sf.T, weight / np.sum(weight))

--- a/skgrf/ensemble/instrumental_regressor.py
+++ b/skgrf/ensemble/instrumental_regressor.py
@@ -1,20 +1,19 @@
 import logging
 import numpy as np
-from sklearn.base import BaseEstimator
 from sklearn.base import RegressorMixin
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf import grf
-from skgrf.base import GRFMixin
+from skgrf.ensemble.base import BaseGRFForest
 from skgrf.tree.instrumental_regressor import GRFTreeInstrumentalRegressor
 from skgrf.utils.validation import check_sample_weight
 
 logger = logging.getLogger(__name__)
 
 
-class GRFInstrumentalRegressor(GRFMixin, RegressorMixin, BaseEstimator):
+class GRFInstrumentalRegressor(BaseGRFForest, RegressorMixin):
     r"""GRF Instrumental regression implementation for sci-kit learn.
 
     Provides a sklearn instrumental regression to the GRF C++ library using Cython.

--- a/skgrf/ensemble/local_linear_regressor.py
+++ b/skgrf/ensemble/local_linear_regressor.py
@@ -1,17 +1,16 @@
 import numpy as np
-from sklearn.base import BaseEstimator
 from sklearn.base import RegressorMixin
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf import grf
-from skgrf.base import GRFMixin
+from skgrf.ensemble.base import BaseGRFForest
 from skgrf.tree.local_linear_regressor import GRFTreeLocalLinearRegressor
 from skgrf.utils.validation import check_sample_weight
 
 
-class GRFLocalLinearRegressor(GRFMixin, RegressorMixin, BaseEstimator):
+class GRFLocalLinearRegressor(BaseGRFForest, RegressorMixin):
     r"""GRF Local Linear Regression implementation for sci-kit learn.
 
     Provides a sklearn regressor interface to the GRF C++ library using Cython.

--- a/skgrf/ensemble/quantile_regressor.py
+++ b/skgrf/ensemble/quantile_regressor.py
@@ -1,15 +1,14 @@
 import numpy as np
-from sklearn.base import BaseEstimator
 from sklearn.base import RegressorMixin
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf import grf
-from skgrf.base import GRFMixin
+from skgrf.ensemble.base import BaseGRFForest
 
 
-class GRFQuantileRegressor(GRFMixin, RegressorMixin, BaseEstimator):
+class GRFQuantileRegressor(BaseGRFForest, RegressorMixin):
     r"""GRF Quantile Regression implementation for sci-kit learn.
 
     Provides a sklearn quantile regressor interface to the GRF C++ library using Cython.

--- a/skgrf/ensemble/regressor.py
+++ b/skgrf/ensemble/regressor.py
@@ -1,17 +1,16 @@
 import numpy as np
-from sklearn.base import BaseEstimator
 from sklearn.base import RegressorMixin
 from sklearn.exceptions import NotFittedError
 from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf import grf
-from skgrf.base import GRFMixin
+from skgrf.ensemble.base import BaseGRFForest
 from skgrf.tree.regressor import GRFTreeRegressor
 from skgrf.utils.validation import check_sample_weight
 
 
-class GRFRegressor(GRFMixin, RegressorMixin, BaseEstimator):
+class GRFRegressor(BaseGRFForest, RegressorMixin):
     r"""GRF Regression implementation for sci-kit learn.
 
     Provides a sklearn regressor interface to the GRF C++ library using Cython.

--- a/skgrf/ensemble/survival.py
+++ b/skgrf/ensemble/survival.py
@@ -5,11 +5,11 @@ from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf import grf
-from skgrf.base import GRFMixin
+from skgrf.ensemble.base import BaseGRFForest
 from skgrf.utils.validation import check_sample_weight
 
 
-class GRFSurvival(GRFMixin, BaseEstimator):
+class GRFSurvival(BaseGRFForest, BaseEstimator):
     r"""GRF Survival implementation for sci-kit learn.
 
     Provides a sklearn survival interface to the GRF C++ library using Cython.

--- a/skgrf/grf.pyx
+++ b/skgrf/grf.pyx
@@ -814,3 +814,13 @@ cdef create_excess_error_matrix(
         result.append(values)
 
     return result
+
+
+cpdef compute_split_frequencies(
+    GRFForest forest_wrapper,
+    size_t max_depth,
+):
+    cdef grf_.SplitFrequencyComputer computer
+
+    split_frequencies = computer.compute(deref(forest_wrapper.forest), max_depth)
+    return split_frequencies

--- a/skgrf/grf_.pxd
+++ b/skgrf/grf_.pxd
@@ -503,3 +503,13 @@ cdef extern from "./grf/src/forest/ForestTrainers.h" namespace "grf":
     cdef ForestTrainer regression_trainer()
     cdef ForestTrainer survival_trainer()
 
+
+cdef extern from "./grf/src/analysis/SplitFrequencyComputer.cpp":
+    pass
+
+cdef extern from "./grf/src/analysis/SplitFrequencyComputer.h" namespace "grf":
+    cdef cppclass SplitFrequencyComputer:
+        vector[vector[size_t]] compute(
+            const Forest& forest,
+            size_t max_depth
+        )

--- a/skgrf/tree/base.py
+++ b/skgrf/tree/base.py
@@ -1,10 +1,15 @@
 import numpy as np
+from sklearn.base import BaseEstimator
 from sklearn.tree._tree import csr_matrix
+from sklearn.utils.validation import check_is_fitted
+
+from skgrf.base import GRFMixin
 
 
-class BaseGRFTree:
+class BaseGRFTree(GRFMixin, BaseEstimator):
     def get_depth(self):
         """Calculate the maximum depth of the tree."""
+        check_is_fitted(self)
         left = self.grf_forest_["_child_nodes"][0][0]
         right = self.grf_forest_["_child_nodes"][0][1]
         root_node = self.grf_forest_["_root_nodes"][0]
@@ -20,6 +25,7 @@ class BaseGRFTree:
 
     def get_n_leaves(self):
         """Calculate the number of leaves of the tree."""
+        check_is_fitted(self)
         left = self.grf_forest_["_child_nodes"][0][0]
         right = self.grf_forest_["_child_nodes"][0][1]
         root_node = self.grf_forest_["_root_nodes"][0]
@@ -37,6 +43,7 @@ class BaseGRFTree:
 
         :param array2d X: training input features
         """
+        check_is_fitted(self)
         return np.apply_along_axis(self._apply, 1, X)
 
     def _apply(self, x, idx=None):
@@ -65,6 +72,7 @@ class BaseGRFTree:
 
         :param array2d X: training input features
         """
+        check_is_fitted(self)
         if hasattr(X, "values"):  # pd.Dataframe
             Xvalues = X.values
         else:

--- a/skgrf/tree/instrumental_regressor.py
+++ b/skgrf/tree/instrumental_regressor.py
@@ -2,13 +2,11 @@ import typing as t
 
 import logging
 import numpy as np
-from sklearn.base import BaseEstimator
 from sklearn.base import RegressorMixin
 from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf import grf
-from skgrf.base import GRFMixin
 from skgrf.tree.base import BaseGRFTree
 from skgrf.utils.validation import check_sample_weight
 
@@ -18,9 +16,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 
-class GRFTreeInstrumentalRegressor(
-    BaseGRFTree, GRFMixin, RegressorMixin, BaseEstimator
-):
+class GRFTreeInstrumentalRegressor(BaseGRFTree, RegressorMixin):
     r"""GRF Tree Instrumental regression implementation for sci-kit learn.
 
     Provides a sklearn tree instrumental regression to the GRF C++ library using Cython.

--- a/skgrf/tree/local_linear_regressor.py
+++ b/skgrf/tree/local_linear_regressor.py
@@ -1,13 +1,11 @@
 import typing as t
 
 import numpy as np
-from sklearn.base import BaseEstimator
 from sklearn.base import RegressorMixin
 from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf import grf
-from skgrf.base import GRFMixin
 from skgrf.tree.base import BaseGRFTree
 from skgrf.utils.validation import check_sample_weight
 
@@ -15,7 +13,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from skgrf.ensemble.local_linear_regressor import GRFLocalLinearRegressor
 
 
-class GRFTreeLocalLinearRegressor(BaseGRFTree, GRFMixin, RegressorMixin, BaseEstimator):
+class GRFTreeLocalLinearRegressor(BaseGRFTree, RegressorMixin):
     r"""GRF Tree Local Linear Regression implementation for sci-kit learn.
 
     Provides a sklearn tree regressor interface to the GRF C++ library using Cython.

--- a/skgrf/tree/quantile_regressor.py
+++ b/skgrf/tree/quantile_regressor.py
@@ -1,20 +1,18 @@
 import typing as t
 
 import numpy as np
-from sklearn.base import BaseEstimator
 from sklearn.base import RegressorMixin
 from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf import grf
-from skgrf.base import GRFMixin
 from skgrf.tree.base import BaseGRFTree
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from skgrf.ensemble.quantile_regressor import GRFQuantileRegressor
 
 
-class GRFTreeQuantileRegressor(BaseGRFTree, GRFMixin, RegressorMixin, BaseEstimator):
+class GRFTreeQuantileRegressor(BaseGRFTree, RegressorMixin):
     r"""GRF Tree Quantile Regression implementation for sci-kit learn.
 
     Provides a sklearn tree quantile regressor interface to the GRF C++ library using

--- a/skgrf/tree/regressor.py
+++ b/skgrf/tree/regressor.py
@@ -1,13 +1,11 @@
 import typing as t
 
 import numpy as np
-from sklearn.base import BaseEstimator
 from sklearn.base import RegressorMixin
 from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf import grf
-from skgrf.base import GRFMixin
 from skgrf.tree.base import BaseGRFTree
 from skgrf.utils.validation import check_sample_weight
 
@@ -15,7 +13,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from skgrf.ensemble.regressor import GRFRegressor
 
 
-class GRFTreeRegressor(BaseGRFTree, GRFMixin, RegressorMixin, BaseEstimator):
+class GRFTreeRegressor(BaseGRFTree, RegressorMixin):
     r"""GRF Tree Regression implementation for sci-kit learn.
 
     Provides a sklearn tree regressor interface to the GRF C++ library using Cython.

--- a/skgrf/tree/survival.py
+++ b/skgrf/tree/survival.py
@@ -1,12 +1,10 @@
 import typing as t
 
 import numpy as np
-from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from skgrf import grf
-from skgrf.base import GRFMixin
 from skgrf.tree.base import BaseGRFTree
 from skgrf.utils.validation import check_sample_weight
 
@@ -14,7 +12,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from skgrf.ensemble.survival import GRFSurvival
 
 
-class GRFTreeSurvival(BaseGRFTree, GRFMixin, BaseEstimator):
+class GRFTreeSurvival(BaseGRFTree):
     r"""GRF Tree Survival implementation for sci-kit learn.
 
     Provides a sklearn tree survival interface to the GRF C++ library using Cython.

--- a/tests/ensemble/test_causal_regressor.py
+++ b/tests/ensemble/test_causal_regressor.py
@@ -163,3 +163,15 @@ class TestGRFCausalRegressor:
         assert len(estimators) == 10
         assert isinstance(estimators[0], GRFTreeCausalRegressor)
         check_is_fitted(estimators[0])
+
+    def test_get_split_frequencies(self, causal_X, causal_y, causal_w):
+        forest = GRFCausalRegressor()
+        forest.fit(causal_X, causal_y, causal_w)
+        sf = forest.get_split_frequencies()
+        assert sf.shape[1] == causal_X.shape[1]
+
+    def test_get_feature_importances(self, causal_X, causal_y, causal_w):
+        forest = GRFCausalRegressor()
+        forest.fit(causal_X, causal_y, causal_w)
+        fi = forest.get_feature_importances()
+        assert len(fi) == causal_X.shape[1]

--- a/tests/ensemble/test_instrumental_regressor.py
+++ b/tests/ensemble/test_instrumental_regressor.py
@@ -152,3 +152,15 @@ class TestGRFInstrumentalRegressor:
         assert len(estimators) == 10
         assert isinstance(estimators[0], GRFTreeInstrumentalRegressor)
         check_is_fitted(estimators[0])
+
+    def test_get_split_frequencies(self, causal_X, causal_y, causal_w):
+        forest = GRFInstrumentalRegressor()
+        forest.fit(causal_X, causal_y, causal_w, causal_w)
+        sf = forest.get_split_frequencies()
+        assert sf.shape[1] == causal_X.shape[1]
+
+    def test_get_feature_importances(self, causal_X, causal_y, causal_w):
+        forest = GRFInstrumentalRegressor()
+        forest.fit(causal_X, causal_y, causal_w, causal_w)
+        fi = forest.get_feature_importances()
+        assert len(fi) == causal_X.shape[1]

--- a/tests/ensemble/test_local_linear_regressor.py
+++ b/tests/ensemble/test_local_linear_regressor.py
@@ -140,3 +140,15 @@ class TestGRFLocalLinearRegressor:
         assert len(estimators) == 10
         assert isinstance(estimators[0], GRFTreeLocalLinearRegressor)
         check_is_fitted(estimators[0])
+
+    def test_get_split_frequencies(self, boston_X, boston_y):
+        forest = GRFLocalLinearRegressor()
+        forest.fit(boston_X, boston_y)
+        sf = forest.get_split_frequencies()
+        assert sf.shape[1] == boston_X.shape[1]
+
+    def test_get_feature_importances(self, boston_X, boston_y):
+        forest = GRFLocalLinearRegressor()
+        forest.fit(boston_X, boston_y)
+        fi = forest.get_feature_importances()
+        assert len(fi) == boston_X.shape[1]

--- a/tests/ensemble/test_quantile_regressor.py
+++ b/tests/ensemble/test_quantile_regressor.py
@@ -133,3 +133,15 @@ class TestGRFQuantileRegressor:
         assert len(estimators) == 10
         assert isinstance(estimators[0], GRFTreeQuantileRegressor)
         check_is_fitted(estimators[0])
+
+    def test_get_split_frequencies(self, boston_X, boston_y):
+        forest = GRFQuantileRegressor(quantiles=[0.2])
+        forest.fit(boston_X, boston_y)
+        sf = forest.get_split_frequencies()
+        assert sf.shape[1] == boston_X.shape[1]
+
+    def test_get_feature_importances(self, boston_X, boston_y):
+        forest = GRFQuantileRegressor(quantiles=[0.2])
+        forest.fit(boston_X, boston_y)
+        fi = forest.get_feature_importances()
+        assert len(fi) == boston_X.shape[1]

--- a/tests/ensemble/test_regressor.py
+++ b/tests/ensemble/test_regressor.py
@@ -139,3 +139,15 @@ class TestGRFRegressor:
         assert len(estimators) == 10
         assert isinstance(estimators[0], GRFTreeRegressor)
         check_is_fitted(estimators[0])
+
+    def test_get_split_frequencies(self, boston_X, boston_y):
+        forest = GRFRegressor()
+        forest.fit(boston_X, boston_y)
+        sf = forest.get_split_frequencies()
+        assert sf.shape[1] == boston_X.shape[1]
+
+    def test_get_feature_importances(self, boston_X, boston_y):
+        forest = GRFRegressor()
+        forest.fit(boston_X, boston_y)
+        fi = forest.get_feature_importances()
+        assert len(fi) == boston_X.shape[1]

--- a/tests/ensemble/test_survival.py
+++ b/tests/ensemble/test_survival.py
@@ -132,3 +132,15 @@ class TestGRFSurvival:
         assert len(estimators) == 10
         assert isinstance(estimators[0], GRFTreeSurvival)
         check_is_fitted(estimators[0])
+
+    def test_get_split_frequencies(self, lung_X, lung_y):
+        forest = GRFSurvival()
+        forest.fit(lung_X, lung_y)
+        sf = forest.get_split_frequencies()
+        assert sf.shape[1] == lung_X.shape[1]
+
+    def test_get_feature_importances(self, lung_X, lung_y):
+        forest = GRFSurvival()
+        forest.fit(lung_X, lung_y)
+        fi = forest.get_feature_importances()
+        assert len(fi) == lung_X.shape[1]


### PR DESCRIPTION
Add feature importance methods to forests

Changes
* Create a BaseGRFForest class with `get_split_frequencies` and `get_feature_importances` methods
* Add SplitFrequencyComputer bindings
* Move GRFMixin and BaseEstimator inheritance to BaseGRFTree
* Add `check_is_fitted` calls to base tree methods.