### PR TITLE
add get estimator method to forests

### DIFF
--- a/skgrf/ensemble/causal_regressor.py
+++ b/skgrf/ensemble/causal_regressor.py
@@ -4,6 +4,7 @@ from sklearn.utils.validation import check_is_fitted
 
 from skgrf.ensemble.boosted_regressor import GRFBoostedRegressor
 from skgrf.ensemble.instrumental_regressor import GRFInstrumentalRegressor
+from skgrf.tree.causal_regressor import GRFTreeCausalRegressor
 
 logger = logging.getLogger(__name__)
 
@@ -90,9 +91,6 @@ class GRFCausalRegressor(GRFInstrumentalRegressor):
 
     @property
     def estimators_(self):
-        # avoiding circular import
-        from skgrf.tree.causal_regressor import GRFTreeCausalRegressor
-
         try:
             check_is_fitted(self)
         except NotFittedError:
@@ -103,6 +101,14 @@ class GRFCausalRegressor(GRFInstrumentalRegressor):
             GRFTreeCausalRegressor.from_forest(self, idx=idx)
             for idx in range(self.n_estimators)
         ]
+
+    def get_estimator(self, idx):
+        """Extract a single estimator tree from the forest.
+
+        :param int idx: The index of the tree to extract.
+        """
+        check_is_fitted(self)
+        return GRFTreeCausalRegressor.from_forest(self, idx=idx)
 
     # noinspection PyMethodOverriding
     def fit(

--- a/skgrf/ensemble/instrumental_regressor.py
+++ b/skgrf/ensemble/instrumental_regressor.py
@@ -103,6 +103,14 @@ class GRFInstrumentalRegressor(BaseGRFForest, RegressorMixin):
             for idx in range(self.n_estimators)
         ]
 
+    def get_estimator(self, idx):
+        """Extract a single estimator tree from the forest.
+
+        :param int idx: The index of the tree to extract.
+        """
+        check_is_fitted(self)
+        return GRFTreeInstrumentalRegressor.from_forest(self, idx=idx)
+
     def fit(
         self,
         X,

--- a/skgrf/ensemble/local_linear_regressor.py
+++ b/skgrf/ensemble/local_linear_regressor.py
@@ -114,6 +114,14 @@ class GRFLocalLinearRegressor(BaseGRFForest, RegressorMixin):
             for idx in range(self.n_estimators)
         ]
 
+    def get_estimator(self, idx):
+        """Extract a single estimator tree from the forest.
+
+        :param int idx: The index of the tree to extract.
+        """
+        check_is_fitted(self)
+        return GRFTreeLocalLinearRegressor.from_forest(self, idx=idx)
+
     def fit(self, X, y, sample_weight=None, cluster=None):
         """Fit the grf forest using training data.
 

--- a/skgrf/ensemble/quantile_regressor.py
+++ b/skgrf/ensemble/quantile_regressor.py
@@ -6,6 +6,7 @@ from sklearn.utils.validation import check_is_fitted
 
 from skgrf import grf
 from skgrf.ensemble.base import BaseGRFForest
+from skgrf.tree.quantile_regressor import GRFTreeQuantileRegressor
 
 
 class GRFQuantileRegressor(BaseGRFForest, RegressorMixin):
@@ -89,9 +90,6 @@ class GRFQuantileRegressor(BaseGRFForest, RegressorMixin):
 
     @property
     def estimators_(self):
-        # avoiding circular import
-        from skgrf.tree.quantile_regressor import GRFTreeQuantileRegressor
-
         try:
             check_is_fitted(self)
         except NotFittedError:
@@ -102,6 +100,14 @@ class GRFQuantileRegressor(BaseGRFForest, RegressorMixin):
             GRFTreeQuantileRegressor.from_forest(self, idx=idx)
             for idx in range(self.n_estimators)
         ]
+
+    def get_estimator(self, idx):
+        """Extract a single estimator tree from the forest.
+
+        :param int idx: The index of the tree to extract.
+        """
+        check_is_fitted(self)
+        return GRFTreeQuantileRegressor.from_forest(self, idx=idx)
 
     def fit(self, X, y, cluster=None):
         """Fit the grf quantile forest using training data.

--- a/skgrf/ensemble/regressor.py
+++ b/skgrf/ensemble/regressor.py
@@ -92,6 +92,14 @@ class GRFRegressor(BaseGRFForest, RegressorMixin):
             for idx in range(self.n_estimators)
         ]
 
+    def get_estimator(self, idx):
+        """Extract a single estimator tree from the forest.
+
+        :param int idx: The index of the tree to extract.
+        """
+        check_is_fitted(self)
+        return GRFTreeRegressor.from_forest(self, idx=idx)
+
     def fit(
         self, X, y, sample_weight=None, cluster=None, compute_oob_predictions=False
     ):

--- a/skgrf/ensemble/survival.py
+++ b/skgrf/ensemble/survival.py
@@ -6,6 +6,7 @@ from sklearn.utils.validation import check_is_fitted
 
 from skgrf import grf
 from skgrf.ensemble.base import BaseGRFForest
+from skgrf.tree.survival import GRFTreeSurvival
 from skgrf.utils.validation import check_sample_weight
 
 
@@ -79,9 +80,6 @@ class GRFSurvival(BaseGRFForest, BaseEstimator):
 
     @property
     def estimators_(self):
-        # avoiding circular import
-        from skgrf.tree.survival import GRFTreeSurvival
-
         try:
             check_is_fitted(self)
         except NotFittedError:
@@ -92,6 +90,14 @@ class GRFSurvival(BaseGRFForest, BaseEstimator):
             GRFTreeSurvival.from_forest(self, idx=idx)
             for idx in range(self.n_estimators)
         ]
+
+    def get_estimator(self, idx):
+        """Extract a single estimator tree from the forest.
+
+        :param int idx: The index of the tree to extract.
+        """
+        check_is_fitted(self)
+        return GRFTreeSurvival.from_forest(self, idx=idx)
 
     def fit(self, X, y, sample_weight=None, cluster=None):
         """Fit the grf forest using training data.

--- a/tests/ensemble/test_causal_regressor.py
+++ b/tests/ensemble/test_causal_regressor.py
@@ -165,6 +165,17 @@ class TestGRFCausalRegressor:
         assert isinstance(estimators[0], GRFTreeCausalRegressor)
         check_is_fitted(estimators[0])
 
+    def test_get_estimator(self, causal_X, causal_y, causal_w):
+        forest = GRFCausalRegressor(n_estimators=10)
+        with pytest.raises(NotFittedError):
+            _ = forest.get_estimator(idx=0)
+        forest.fit(causal_X, causal_y, causal_w, causal_w)
+        estimator = forest.get_estimator(0)
+        check_is_fitted(estimator)
+        assert isinstance(estimator, GRFTreeCausalRegressor)
+        with pytest.raises(IndexError):
+            _ = forest.get_estimator(idx=20)
+
     def test_get_split_frequencies(self, causal_X, causal_y, causal_w):
         forest = GRFCausalRegressor()
         forest.fit(causal_X, causal_y, causal_w)

--- a/tests/ensemble/test_instrumental_regressor.py
+++ b/tests/ensemble/test_instrumental_regressor.py
@@ -154,6 +154,17 @@ class TestGRFInstrumentalRegressor:
         assert isinstance(estimators[0], GRFTreeInstrumentalRegressor)
         check_is_fitted(estimators[0])
 
+    def test_get_estimator(self, causal_X, causal_y, causal_w):
+        forest = GRFInstrumentalRegressor(n_estimators=10)
+        with pytest.raises(NotFittedError):
+            _ = forest.get_estimator(idx=0)
+        forest.fit(causal_X, causal_y, causal_w, causal_w)
+        estimator = forest.get_estimator(0)
+        check_is_fitted(estimator)
+        assert isinstance(estimator, GRFTreeInstrumentalRegressor)
+        with pytest.raises(IndexError):
+            _ = forest.get_estimator(idx=20)
+
     def test_get_split_frequencies(self, causal_X, causal_y, causal_w):
         forest = GRFInstrumentalRegressor()
         forest.fit(causal_X, causal_y, causal_w, causal_w)

--- a/tests/ensemble/test_local_linear_regressor.py
+++ b/tests/ensemble/test_local_linear_regressor.py
@@ -142,6 +142,17 @@ class TestGRFLocalLinearRegressor:
         assert isinstance(estimators[0], GRFTreeLocalLinearRegressor)
         check_is_fitted(estimators[0])
 
+    def test_get_estimator(self, boston_X, boston_y):
+        forest = GRFLocalLinearRegressor(n_estimators=10)
+        with pytest.raises(NotFittedError):
+            _ = forest.get_estimator(idx=0)
+        forest.fit(boston_X, boston_y)
+        estimator = forest.get_estimator(0)
+        check_is_fitted(estimator)
+        assert isinstance(estimator, GRFTreeLocalLinearRegressor)
+        with pytest.raises(IndexError):
+            _ = forest.get_estimator(idx=20)
+
     def test_get_split_frequencies(self, boston_X, boston_y):
         forest = GRFLocalLinearRegressor()
         forest.fit(boston_X, boston_y)

--- a/tests/ensemble/test_quantile_regressor.py
+++ b/tests/ensemble/test_quantile_regressor.py
@@ -135,6 +135,17 @@ class TestGRFQuantileRegressor:
         assert isinstance(estimators[0], GRFTreeQuantileRegressor)
         check_is_fitted(estimators[0])
 
+    def test_get_estimator(self, boston_X, boston_y):
+        forest = GRFQuantileRegressor(n_estimators=10, quantiles=[0.2])
+        with pytest.raises(NotFittedError):
+            _ = forest.get_estimator(idx=0)
+        forest.fit(boston_X, boston_y)
+        estimator = forest.get_estimator(0)
+        check_is_fitted(estimator)
+        assert isinstance(estimator, GRFTreeQuantileRegressor)
+        with pytest.raises(IndexError):
+            _ = forest.get_estimator(idx=20)
+
     def test_get_split_frequencies(self, boston_X, boston_y):
         forest = GRFQuantileRegressor(quantiles=[0.2])
         forest.fit(boston_X, boston_y)

--- a/tests/ensemble/test_regressor.py
+++ b/tests/ensemble/test_regressor.py
@@ -141,6 +141,17 @@ class TestGRFRegressor:
         assert isinstance(estimators[0], GRFTreeRegressor)
         check_is_fitted(estimators[0])
 
+    def test_get_estimator(self, boston_X, boston_y):
+        forest = GRFRegressor(n_estimators=10)
+        with pytest.raises(NotFittedError):
+            _ = forest.get_estimator(idx=0)
+        forest.fit(boston_X, boston_y)
+        estimator = forest.get_estimator(0)
+        check_is_fitted(estimator)
+        assert isinstance(estimator, GRFTreeRegressor)
+        with pytest.raises(IndexError):
+            _ = forest.get_estimator(idx=20)
+
     def test_get_split_frequencies(self, boston_X, boston_y):
         forest = GRFRegressor()
         forest.fit(boston_X, boston_y)

--- a/tests/ensemble/test_survival.py
+++ b/tests/ensemble/test_survival.py
@@ -134,6 +134,17 @@ class TestGRFSurvival:
         assert isinstance(estimators[0], GRFTreeSurvival)
         check_is_fitted(estimators[0])
 
+    def test_get_estimator(self, lung_X, lung_y):
+        forest = GRFSurvival(n_estimators=10)
+        with pytest.raises(NotFittedError):
+            _ = forest.get_estimator(idx=0)
+        forest.fit(lung_X, lung_y)
+        estimator = forest.get_estimator(0)
+        check_is_fitted(estimator)
+        assert isinstance(estimator, GRFTreeSurvival)
+        with pytest.raises(IndexError):
+            _ = forest.get_estimator(idx=20)
+
     def test_get_split_frequencies(self, lung_X, lung_y):
         forest = GRFSurvival()
         forest.fit(lung_X, lung_y)


### PR DESCRIPTION
Adds a `get_estimator(idx)` method to forests to enable extraction of single tree estimators without having to serialize the full list of trees via the `estimators_` property.