### PR TITLE
add Tree.values

### DIFF
--- a/skgrf/base.py
+++ b/skgrf/base.py
@@ -29,6 +29,7 @@ class GRFMixin:
             pass
 
     def _ensure_ptr(self):
+        """Ensure that a pointer to the C++ forest exists."""
         if hasattr(self, "grf_forest_") and not hasattr(self, "grf_forest_cpp_"):
             self.grf_forest_cpp_ = grf.GRFForest(self.grf_forest_)
 
@@ -59,12 +60,14 @@ class GRFMixin:
             return max(counts)
 
     def _check_mtry(self, X):
+        """Validate mtry."""
         if self.mtry is None:
             return min(int(np.ceil(np.sqrt(X.shape[1] + 20))), X.shape[1])
         else:
             return self.mtry
 
     def _check_sample_fraction(self, oob=False):
+        """Validate sample fraction"""
         if hasattr(self, "ci_group_size") and self.ci_group_size >= 2:
             if self.sample_fraction <= 0 or self.sample_fraction > 0.5:
                 raise ValueError(
@@ -80,14 +83,17 @@ class GRFMixin:
             )
 
     def _check_alpha(self):
+        """Validate alpha."""
         if self.alpha <= 0 or self.alpha >= 0.25:
             raise ValueError("alpha must be between 0 and 0.25")
 
     def _check_reduced_form_weight(self):
+        """Validate reduced form weight."""
         if self.reduced_form_weight < 0 or self.reduced_form_weight > 1:
             raise ValueError("reduced_form_weight must be between 0 and 1")
 
     def _check_boost_error_reduction(self):
+        """Validate boost error reduction."""
         if self.boost_error_reduction < 0 or self.boost_error_reduction > 1:
             raise ValueError("reduced_form_weight must be between 0 and 1")
 
@@ -136,12 +142,14 @@ class GRFMixin:
         return np.concatenate(concats, axis=1)
 
     def _check_num_samples(self, X):
+        """Validate sample fraction against dataset."""
         if len(X) * self.sample_fraction < 1:
             raise ValueError(
                 "The sample fraction is too small, resulting in less than 1 sample for fitting."
             )
 
     def _set_sample_weights(self, sample_weight):
+        """Set leaf weights for access in ``Tree``."""
         self.grf_forest_["leaf_weights"] = []
         for tree in self.grf_forest_["leaf_samples"]:
             self.grf_forest_["leaf_weights"].append([])
@@ -150,6 +158,63 @@ class GRFMixin:
                     sum([sample_weight[idx] for idx in node])
                 )
 
+    def _get_sample_values(self, values):
+        """Map the leaf samples to corresponding values.
+
+        Used to get corresponding sample weights or targets.
+        """
+        mapped_values = []
+        for tree in self.grf_forest_["leaf_samples"]:
+            mapped_values.append([])
+            for node in tree:
+                mapped_values[-1].append([values[idx] for idx in node])
+        return mapped_values
+
+    def _get_values(self, left, right, idx, values):
+        """Recursively sum the child values through a tree."""
+        left_values = (
+            values[idx]
+            if left[idx] == 0
+            else self._get_values(left, right, left[idx], values)
+        )
+        right_values = (
+            values[idx]
+            if right[idx] == 0
+            else self._get_values(left, right, right[idx], values)
+        )
+        values[idx] = left_values + right_values
+        return values[idx]
+
+    def _set_node_values(self, y, sample_weight):
+        """Set the node values for ``Tree.value``."""
+        forest_values = self._get_sample_values(y)
+        forest_weights = self._get_sample_values(sample_weight)
+        self.grf_forest_["node_values"] = []
+        for idx in range(self.grf_forest_["num_trees"]):
+            left = self.grf_forest_["child_nodes"][idx][0]
+            right = self.grf_forest_["child_nodes"][idx][1]
+            root = self.grf_forest_["root_nodes"][idx]
+            values = forest_values[idx]
+            self._get_values(
+                left,
+                right,
+                root,
+                values,
+            )
+            weights = forest_weights[idx]
+            self._get_values(
+                left,
+                right,
+                root,
+                weights,
+            )
+            values = [
+                np.average(v, weights=w, axis=0) if v else np.nan
+                for v, w in zip(values, weights)
+            ]
+            self.grf_forest_["node_values"].append(values)
+
     def _set_n_classes(self):
+        """Set num classes for ``Tree.n_classes``."""
         # for accessing in Tree
         self.grf_forest_["n_classes"] = self.n_classes_

--- a/skgrf/ensemble/instrumental_regressor.py
+++ b/skgrf/ensemble/instrumental_regressor.py
@@ -217,9 +217,9 @@ class GRFInstrumentalRegressor(BaseGRFForest, RegressorMixin):
             self.seed,
         )
         self._ensure_ptr()
-        self._set_sample_weights(
-            sample_weight if sample_weight is not None else np.ones(len(X))
-        )
+        sample_weight = sample_weight if sample_weight is not None else np.ones(len(X))
+        self._set_sample_weights(sample_weight)
+        self._set_node_values(y, sample_weight)
         self._set_n_classes()
         return self
 

--- a/skgrf/ensemble/local_linear_regressor.py
+++ b/skgrf/ensemble/local_linear_regressor.py
@@ -205,9 +205,9 @@ class GRFLocalLinearRegressor(BaseGRFForest, RegressorMixin):
             self.seed,
         )
         self._ensure_ptr()
-        self._set_sample_weights(
-            sample_weight if sample_weight is not None else np.ones(len(X))
-        )
+        sample_weight = sample_weight if sample_weight is not None else np.ones(len(X))
+        self._set_sample_weights(sample_weight)
+        self._set_node_values(y, sample_weight)
         self._set_n_classes()
         return self
 

--- a/skgrf/ensemble/quantile_regressor.py
+++ b/skgrf/ensemble/quantile_regressor.py
@@ -163,7 +163,9 @@ class GRFQuantileRegressor(BaseGRFForest, RegressorMixin):
             self.seed,
         )
         self._ensure_ptr()
-        self._set_sample_weights(np.ones(len(X)))
+        sample_weight = np.ones(len(X))
+        self._set_sample_weights(sample_weight)
+        self._set_node_values(y, sample_weight)
         self._set_n_classes()
         return self
 

--- a/skgrf/ensemble/regressor.py
+++ b/skgrf/ensemble/regressor.py
@@ -157,9 +157,9 @@ class GRFRegressor(BaseGRFForest, RegressorMixin):
             self.seed,
         )
         self._ensure_ptr()
-        self._set_sample_weights(
-            sample_weight if sample_weight is not None else np.ones(len(X))
-        )
+        sample_weight = sample_weight if sample_weight is not None else np.ones(len(X))
+        self._set_sample_weights(sample_weight)
+        self._set_node_values(y, sample_weight)
         self._set_n_classes()
         return self
 

--- a/skgrf/ensemble/survival.py
+++ b/skgrf/ensemble/survival.py
@@ -166,9 +166,9 @@ class GRFSurvival(BaseGRFForest, BaseEstimator):
             self.seed,
         )
         self._ensure_ptr()
-        self._set_sample_weights(
-            sample_weight if sample_weight is not None else np.ones(len(X))
-        )
+        sample_weight = sample_weight if sample_weight is not None else np.ones(len(X))
+        self._set_sample_weights(sample_weight)
+        self._set_node_values(y, sample_weight)
         self._set_n_classes()
         return self
 

--- a/skgrf/tree/_tree.py
+++ b/skgrf/tree/_tree.py
@@ -215,3 +215,9 @@ class Tree:
             weighted_n_samples,
         )
         return np.array(weighted_n_samples)
+
+    @property
+    def value(self):
+        """The constant prediction value of each node."""
+        values = self.grf_forest["node_values"][0]
+        return np.reshape(values, (len(values), 1, 1))

--- a/skgrf/tree/instrumental_regressor.py
+++ b/skgrf/tree/instrumental_regressor.py
@@ -241,9 +241,9 @@ class GRFTreeInstrumentalRegressor(BaseGRFTree, RegressorMixin):
             self.seed,
         )
         self._ensure_ptr()
-        self._set_sample_weights(
-            sample_weight if sample_weight is not None else np.ones(len(X))
-        )
+        sample_weight = sample_weight if sample_weight is not None else np.ones(len(X))
+        self._set_sample_weights(sample_weight)
+        self._set_node_values(y, sample_weight)
         self._set_n_classes()
         return self
 

--- a/skgrf/tree/local_linear_regressor.py
+++ b/skgrf/tree/local_linear_regressor.py
@@ -229,9 +229,9 @@ class GRFTreeLocalLinearRegressor(BaseGRFTree, RegressorMixin):
             self.seed,
         )
         self._ensure_ptr()
-        self._set_sample_weights(
-            sample_weight if sample_weight is not None else np.ones(len(X))
-        )
+        sample_weight = sample_weight if sample_weight is not None else np.ones(len(X))
+        self._set_sample_weights(sample_weight)
+        self._set_node_values(y, sample_weight)
         self._set_n_classes()
         return self
 

--- a/skgrf/tree/quantile_regressor.py
+++ b/skgrf/tree/quantile_regressor.py
@@ -187,7 +187,9 @@ class GRFTreeQuantileRegressor(BaseGRFTree, RegressorMixin):
             self.seed,
         )
         self._ensure_ptr()
-        self._set_sample_weights(np.ones(len(X)))
+        sample_weight = np.ones(len(X))
+        self._set_sample_weights(sample_weight)
+        self._set_node_values(y, sample_weight)
         self._set_n_classes()
         return self
 

--- a/skgrf/tree/regressor.py
+++ b/skgrf/tree/regressor.py
@@ -171,9 +171,9 @@ class GRFTreeRegressor(BaseGRFTree, RegressorMixin):
             self.seed,
         )
         self._ensure_ptr()
-        self._set_sample_weights(
-            sample_weight if sample_weight is not None else np.ones(len(X))
-        )
+        sample_weight = sample_weight if sample_weight is not None else np.ones(len(X))
+        self._set_sample_weights(sample_weight)
+        self._set_node_values(y, sample_weight)
         self._set_n_classes()
         return self
 

--- a/skgrf/tree/survival.py
+++ b/skgrf/tree/survival.py
@@ -187,9 +187,9 @@ class GRFTreeSurvival(BaseGRFTree):
             self.seed,
         )
         self._ensure_ptr()
-        self._set_sample_weights(
-            sample_weight if sample_weight is not None else np.ones(len(X))
-        )
+        sample_weight = sample_weight if sample_weight is not None else np.ones(len(X))
+        self._set_sample_weights(sample_weight)
+        self._set_node_values(y, sample_weight)
         self._set_n_classes()
         return self
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,7 +13,6 @@ def test_plot():
     forest = GRFRegressor()
     forest.fit(boston_X, boston_y)
     estimator = forest.get_estimator(0)
-    estimator.criterion = "mse"  # criterion must be set
     plt.figure()
     plot_tree(
         estimator,
@@ -31,7 +30,6 @@ def test_shap(boston_X, boston_y):
 
     forest = GRFRegressor()
     forest.fit(boston_X, boston_y)
-    forest.criterion = "mse"
 
     explainer = TreeExplainer(model=forest, data=boston_X)
     shap_values = explainer.shap_values(boston_X, check_additivity=True)

--- a/tests/tree/test_causal_regressor.py
+++ b/tests/tree/test_causal_regressor.py
@@ -195,5 +195,6 @@ class TestGRFTreeCausalRegressor:
         capacity = tree_.capacity
         n_outputs = tree_.n_outputs
         n_classes = tree_.n_classes
+        value = tree_.value
 
     # endregion

--- a/tests/tree/test_instrumental_regressor.py
+++ b/tests/tree/test_instrumental_regressor.py
@@ -187,5 +187,6 @@ class TestGRFTreeInstrumentalRegressor:
         capacity = tree_.capacity
         n_outputs = tree_.n_outputs
         n_classes = tree_.n_classes
+        value = tree_.value
 
     # endregion

--- a/tests/tree/test_local_linear_regressor.py
+++ b/tests/tree/test_local_linear_regressor.py
@@ -177,5 +177,6 @@ class TestGRFTreeLocalLinearRegressor:
         capacity = tree_.capacity
         n_outputs = tree_.n_outputs
         n_classes = tree_.n_classes
+        value = tree_.value
 
     # endregion

--- a/tests/tree/test_quantile_regressor.py
+++ b/tests/tree/test_quantile_regressor.py
@@ -188,5 +188,6 @@ class TestGRFTreeQuantileRegressor:
         capacity = tree_.capacity
         n_outputs = tree_.n_outputs
         n_classes = tree_.n_classes
+        value = tree_.value
 
     # endregion

--- a/tests/tree/test_regressor.py
+++ b/tests/tree/test_regressor.py
@@ -179,5 +179,6 @@ class TestGRFTreeRegressor:
         capacity = tree_.capacity
         n_outputs = tree_.n_outputs
         n_classes = tree_.n_classes
+        value = tree_.value
 
     # endregion

--- a/tests/tree/test_survival.py
+++ b/tests/tree/test_survival.py
@@ -180,5 +180,6 @@ class TestGRFTreeSurvival:
         capacity = tree_.capacity
         n_outputs = tree_.n_outputs
         n_classes = tree_.n_classes
+        value = tree_.value
 
     # endregion


### PR DESCRIPTION
Calculates node_values at fit time rather than at access time. Compared to #55 this adds time to training but keeps the size of the serialized forest small, since we calculate the node values rather than store all the y-values and weights required to build them in Tree.