### PR TITLE
use oldest supported numpy for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,7 @@ jobs:
     - name: Install deps
       run: |
         cp build/**/grf*.so skgrf
+        cp build/**/grf*.dylib skgrf
         poetry install --no-root
 
     - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,15 +45,12 @@ jobs:
       run: |
         poetry run python buildpre.py
         poetry build
+        poetry run python -c "from skgrf import grf"
 
     - name: Install deps
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: |
         poetry install --no-root
-
-    - name: Install
-      run: |
-        poetry install
 
     - name: Format
       run: |
@@ -117,15 +114,12 @@ jobs:
       run: |
         poetry run python buildpre.py
         poetry build
+        poetry run python -c "from skgrf import grf"
 
     - name: Install deps
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: |
         poetry install --no-root
-
-    - name: Install
-      run: |
-        poetry install
 
     - name: Test
       run: |
@@ -182,15 +176,12 @@ jobs:
       run: |
         poetry run python buildpre.py
         poetry build
+        poetry run python -c "from skgrf import grf"
 
     - name: Install deps
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: |
         poetry install --no-root
-
-    - name: Install
-      run: |
-        poetry install
 
     - name: Test
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,8 +119,8 @@ jobs:
 
     - name: Install deps
       run: |
-        cp build/**/grf*.so skgrf
-        cp build/**/grf*.dylib skgrf
+        cp build/**/grf*.so skgrf || true
+        cp build/**/grf*.dylib skgrf || true
         poetry install --no-root
 
     - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,11 +46,10 @@ jobs:
         poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
         poetry build
-        poetry run pip install -U pip
-        poetry run pip install dist/*whl
 
     - name: Install deps
       run: |
+        cp build/**/grf*.dylib skgrf
         poetry install --no-root
 
     - name: Format
@@ -119,8 +118,7 @@ jobs:
 
     - name: Install deps
       run: |
-        cp build/**/grf*.so skgrf || true
-        cp build/**/grf*.dylib skgrf || true
+        cp build/**/grf*.dylib skgrf
         poetry install --no-root
 
     - name: Test
@@ -179,11 +177,10 @@ jobs:
         poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
         poetry build
-        poetry run pip install -U pip
-        poetry run pip install dist/*whl
 
     - name: Install deps
       run: |
+        cp build/**/grf*.so skgrf
         poetry install --no-root
 
     - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,11 +116,10 @@ jobs:
         poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
         poetry build
-        poetry run pip install -U pip
-        poetry run pip install dist/*whl
 
     - name: Install deps
       run: |
+        cp build/**/grf*.so skgrf
         poetry install --no-root
 
     - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,10 @@ jobs:
       run: |
         poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
-        poetry build
+        poetry run python build.py build_ext --inplace --force
 
     - name: Install deps
       run: |
-        cp build/**/grf*.dylib skgrf
         poetry install --no-root
 
     - name: Format
@@ -114,11 +113,10 @@ jobs:
       run: |
         poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
-        poetry build
+        poetry run python build.py build_ext --inplace --force
 
     - name: Install deps
       run: |
-        cp build/**/grf*.dylib skgrf
         poetry install --no-root
 
     - name: Test
@@ -176,11 +174,10 @@ jobs:
       run: |
         poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
-        poetry build
+        poetry run python build.py build_ext --inplace --force
 
     - name: Install deps
       run: |
-        cp build/**/grf*.so skgrf
         poetry install --no-root
 
     - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,14 +43,15 @@ jobs:
 
     - name: Build
       run: |
+        poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
         poetry build
-        poetry run python -c "from skgrf import grf"
 
-    - name: Install deps
+    - name: Install
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: |
         poetry install --no-root
+        poetry run pip install dist/*whl
 
     - name: Format
       run: |
@@ -112,14 +113,15 @@ jobs:
 
     - name: Build
       run: |
+        poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
         poetry build
-        poetry run python -c "from skgrf import grf"
 
-    - name: Install deps
+    - name: Install
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: |
         poetry install --no-root
+        poetry run pip install dist/*whl
 
     - name: Test
       run: |
@@ -174,14 +176,15 @@ jobs:
 
     - name: Build
       run: |
+        poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
         poetry build
-        poetry run python -c "from skgrf import grf"
 
-    - name: Install deps
+    - name: Install
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: |
         poetry install --no-root
+        poetry run pip install dist/*whl
 
     - name: Test
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,10 @@ jobs:
     - name: Install deps
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: |
+        poetry install --no-root
+
+    - name: Install
+      run: |
         poetry install
 
     - name: Format
@@ -117,6 +121,10 @@ jobs:
     - name: Install deps
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: |
+        poetry install --no-root
+
+    - name: Install
+      run: |
         poetry install
 
     - name: Test
@@ -177,6 +185,10 @@ jobs:
 
     - name: Install deps
       if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: |
+        poetry install --no-root
+
+    - name: Install
       run: |
         poetry install
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,9 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.asdf
-        key: v1-${{ runner.os }}-asdf-${{ hashFiles(format('{0}{1}', github.workspace, '/poetry.lock')) }}
+        key: v2-${{ runner.os }}-asdf-${{ hashFiles(format('{0}{1}', github.workspace, '/poetry.lock')) }}
         restore-keys: |
-          v1-${{ runner.os }}-asdf-
+          v2-${{ runner.os }}-asdf-
 
     - name: Install tools
       # pip 20.1 fails on generation of multiple .egg-info dirs
@@ -90,9 +90,9 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.asdf
-        key: v1-${{ runner.os }}-${{ matrix.python-version }}-asdf-${{ hashFiles(format('{0}{1}', github.workspace, '/poetry.lock')) }}
+        key: v2-${{ runner.os }}-${{ matrix.python-version }}-asdf-${{ hashFiles(format('{0}{1}', github.workspace, '/poetry.lock')) }}
         restore-keys: |
-          v1-${{ runner.os }}-${{ matrix.python-version }}-asdf-
+          v2-${{ runner.os }}-${{ matrix.python-version }}-asdf-
 
     - name: Install python
       if: steps.cache-deps.outputs.cache-hit != 'true'
@@ -153,9 +153,9 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.asdf
-        key: v1-${{ runner.os }}-${{ matrix.python-version }}-asdf-${{ hashFiles(format('{0}{1}', github.workspace, '/poetry.lock')) }}
+        key: v2-${{ runner.os }}-${{ matrix.python-version }}-asdf-${{ hashFiles(format('{0}{1}', github.workspace, '/poetry.lock')) }}
         restore-keys: |
-          v1-${{ runner.os }}-${{ matrix.python-version }}-asdf-
+          v2-${{ runner.os }}-${{ matrix.python-version }}-asdf-
 
     - name: Install python
       if: steps.cache-deps.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
         poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
         poetry build
+        poetry run pip install -U pip
         poetry run pip install dist/*whl
 
     - name: Install deps
@@ -115,6 +116,7 @@ jobs:
         poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
         poetry build
+        poetry run pip install -U pip
         poetry run pip install dist/*whl
 
     - name: Install deps
@@ -177,6 +179,7 @@ jobs:
         poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
         poetry build
+        poetry run pip install -U pip
         poetry run pip install dist/*whl
 
     - name: Install deps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,12 +46,11 @@ jobs:
         poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
         poetry build
+        poetry run pip install dist/*whl
 
-    - name: Install
-      if: steps.cache-deps.outputs.cache-hit != 'true'
+    - name: Install deps
       run: |
         poetry install --no-root
-        poetry run pip install dist/*whl
 
     - name: Format
       run: |
@@ -116,12 +115,11 @@ jobs:
         poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
         poetry build
+        poetry run pip install dist/*whl
 
-    - name: Install
-      if: steps.cache-deps.outputs.cache-hit != 'true'
+    - name: Install deps
       run: |
         poetry install --no-root
-        poetry run pip install dist/*whl
 
     - name: Test
       run: |
@@ -179,12 +177,11 @@ jobs:
         poetry run pip install cython oldest-supported-numpy
         poetry run python buildpre.py
         poetry build
+        poetry run pip install dist/*whl
 
-    - name: Install
-      if: steps.cache-deps.outputs.cache-hit != 'true'
+    - name: Install deps
       run: |
         poetry install --no-root
-        poetry run pip install dist/*whl
 
     - name: Test
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,14 +41,14 @@ jobs:
         poetry run pip install pip==20.0.2
         poetry run pip install -U setuptools wheel
 
-    - name: Install deps
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: |
-        poetry install --no-root
-
     - name: Build
       run: |
         poetry run python buildpre.py
+        poetry build
+
+    - name: Install deps
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: |
         poetry install
 
     - name: Format
@@ -109,14 +109,14 @@ jobs:
         poetry run pip install pip==20.0.2
         poetry run pip install -U setuptools wheel
 
-    - name: Install deps
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: |
-        poetry install --no-root
-
     - name: Build
       run: |
         poetry run python buildpre.py
+        poetry build
+
+    - name: Install deps
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: |
         poetry install
 
     - name: Test
@@ -170,14 +170,14 @@ jobs:
         poetry run pip install pip==20.0.2
         poetry run pip install -U setuptools wheel
 
-    - name: Install deps
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: |
-        poetry install --no-root
-
     - name: Build
       run: |
         poetry run python buildpre.py
+        poetry build
+
+    - name: Install deps
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: |
         poetry install
 
     - name: Test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ pytest-xdist = "^2.2.1"
 #matplotlib = {version = "^3.4.2", python = ">=3.7,<4.0.0"}
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "cython", "numpy"]
+requires = ["poetry-core>=1.0.0", "cython", "oldest-supported-numpy"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.black]


### PR DESCRIPTION
Modify the build system requirements from `numpy` to `oldest-supported-numpy`, which should allow wheels to be more compatible with other packages on any platform.

To ensure we are also building with the oldest numpy, we also update the build order so that we do a package build before installing any of the dependencies. This ensures that the numpy installed from deps is done _after_ the oldest supported numpy version is installed for building.